### PR TITLE
Multiple bug fixes and tox testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,4 +21,3 @@ exclude_lines =
     if __name__ == .__main__.:
     if PY3
     if not PY3
-

--- a/.coveragerc
+++ b/.coveragerc
@@ -19,4 +19,6 @@ exclude_lines =
     if 0:
     if False:
     if __name__ == .__main__.:
+    if PY3
+    if not PY3
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+[run]
+branch = True
+source =
+    kdcproxy
+    tests.py
+
+[paths]
+source =
+   kdcproxy
+   .tox/*/lib/python*/site-packages/kdcproxy
+
+[report]
+ignore_errors = False
+precision = 1
+exclude_lines =
+    pragma: no cover
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if False:
+    if __name__ == .__main__.:
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+/.tox
+/dist
+/build
+/MANIFEST

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+__pycache__
+/.coverage
 /.tox
 /dist
 /build

--- a/README
+++ b/README
@@ -1,8 +1,9 @@
+====================
 Welcome to kdcproxy!
-=====================
+====================
 
 This package contains a WSGI module for proxying KDC requests over HTTP by
-following the [MS-KKDCP] protocol. It aims to be simple to deploy, with
+following the `[MS-KKDCP]`_ protocol. It aims to be simple to deploy, with
 minimal configuration.
 
 Deploying kdcproxy
@@ -11,11 +12,26 @@ Deploying kdcproxy
 The kdcproxy module follows the standard WSGI protocol for deploying Python
 web applications. This makes configuration simple. Simply load up your favorite
 WSGI-enabled web server and point it to the module. For example, if you wish
-to use mod_wsgi, try something like this:
+to use mod_wsgi, try something like this::
 
-    WSGIScriptAlias /kdc /path/to/kdcproxy/__init__.py
+    WSGIDaemonProcess kdcproxy processes=2 threads=15 maximum-requests=1000 \
+        display-name=%{GROUP}
+    WSGIProcessGroup kdcproxy
+    WSGIApplicationGroup kdcproxy
+    WSGIImportScript /usr/lib/python2.7/site-packages/kdcproxy/__init__.py \
+        process-group=kdcproxy application-group=kdcproxy
+    WSGIScriptAlias /KdcProxy /usr/lib/python2.7/site-packages/kdcproxy/__init__.py
+    WSGIScriptReloading Off
 
-For more information, see the documentation of your WSGI server.
+    <Location "/KdcProxy">
+    Satisfy Any
+    Order Deny,Allow
+    Allow from all
+    </Location>
+
+`[MS-KKDCP]`_ suggests /KdcProxy as end point. For more information, see the
+documentation of your WSGI server.
+
 
 Configuring kdcproxy
 ====================
@@ -85,5 +101,53 @@ section.
 
 For more information, see the documentation for MIT's krb5.conf.
 
-[MS-KKDCP]: http://msdn.microsoft.com/en-us/library/hh553774.aspx
 
+Configuring a client for kdcproxy
+=================================
+
+HTTPS proxy support is available since Kerberos 5 release 1.13. Some
+vendors have backported the feature to older versions of krb5, too. In order
+to use a HTTPS proxy, simply point the kdc and kpasswd options to the proxy URL like
+explained in `HTTPS proxy`_ configuration guide. Your ``/etc/krb5.conf`` may
+look like this::
+
+    [libdefaults]
+        default_realm = EXAMPLE.COM
+
+    [realms]
+        EXAMPLE.COM = {
+            http_anchors = FILE:/etc/krb5/cacert.pem
+            kdc = https://kerberos.example.com/KdcProxy
+            kpasswd_server = https://kerberos.example.com/KdcProxy
+    }
+
+
+To debug the feature, set the environment variable ``KRB5_TRACE`` to
+``/dev/stdout``. When the feature is correctly configured, you should see
+two POST requests in the access log of the WSGI server and a line containing
+``Sending HTTPS request`` in the debug output of kinit::
+
+    $ env KRB5_TRACE=/dev/stdout kinit user
+    [1037] 1431509096.26305: Getting initial credentials for user@EXAMPLE.COM
+    [1037] 1431509096.26669: Sending request (169 bytes) to EXAMPLE.COM
+    [1037] 1431509096.26939: Resolving hostname kerberos.example.com
+    [1037] 1431509096.34377: TLS certificate name matched "kerberos.example.com"
+    [1037] 1431509096.38791: Sending HTTPS request to https 128.66.0.1:443
+    [1037] 1431509096.46387: Received answer (344 bytes) from https 128.66.0.1:443
+    [1037] 1431509096.46411: Terminating TCP connection to https 128.66.0.1:443
+    ...
+
+If kinit still connects to port 88/TCP or port 88/UDP, then System Security
+Services Daemon's Kerberos locator plugin might override the settings in
+/etc/krb5.conf. With the environment variable ``SSSD_KRB5_LOCATOR_DEBUG=1``,
+kinit and sssd_krb5_locator_plugin print out additional debug information. To
+disable the KDC locator feature, edit ``/etc/sssd/sssd.conf`` and set
+``krb5_use_kdcinfo`` to False::
+
+    [domain/example.com]
+    krb5_use_kdcinfo = False
+
+Don't forget to restart SSSD!
+
+.. _[MS-KKDCP]: http://msdn.microsoft.com/en-us/library/hh553774.aspx
+.. _HTTPS Proxy: http://web.mit.edu/kerberos/krb5-current/doc/admin/https.html

--- a/README
+++ b/README
@@ -16,17 +16,17 @@ to use mod_wsgi, try something like this::
 
     WSGIDaemonProcess kdcproxy processes=2 threads=15 maximum-requests=1000 \
         display-name=%{GROUP}
-    WSGIProcessGroup kdcproxy
-    WSGIApplicationGroup kdcproxy
     WSGIImportScript /usr/lib/python2.7/site-packages/kdcproxy/__init__.py \
         process-group=kdcproxy application-group=kdcproxy
     WSGIScriptAlias /KdcProxy /usr/lib/python2.7/site-packages/kdcproxy/__init__.py
     WSGIScriptReloading Off
 
     <Location "/KdcProxy">
-    Satisfy Any
-    Order Deny,Allow
-    Allow from all
+        Satisfy Any
+        Order Deny,Allow
+        Allow from all
+        WSGIProcessGroup kdcproxy
+        WSGIApplicationGroup kdcproxy
     </Location>
 
 `[MS-KKDCP]`_ suggests /KdcProxy as end point. For more information, see the

--- a/README
+++ b/README
@@ -101,6 +101,15 @@ section.
 
 For more information, see the documentation for MIT's krb5.conf.
 
+Configuration reloading
+-----------------------
+
+kdcproxy reads its configurtion files when package is imported and a global
+WSGI application object is instantiated. For now kdcproxy does neither
+monitor its configuration files for changes nor supports runtime updates. You
+have to restart the WSGI process to make modification available. With Apache
+HTTP and mod_wsgi, a reload of the server also restarts all WSGI daemons.
+
 
 Configuring a client for kdcproxy
 =================================

--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -41,13 +41,14 @@ class HTTPException(Exception):
 
     def __init__(self, code, msg, headers=[]):
         headers = list(filter(lambda h: h[0] != 'Content-Length', headers))
-        headers.append(('Content-Length', str(len(msg))))
 
         if 'Content-Type' not in dict(headers):
-            headers.append(('Content-Type', 'text/plain'))
+            headers.append(('Content-Type', 'text/plain; charset=utf-8'))
 
         if sys.version_info.major == 3 and isinstance(msg, str):
-            msg = bytes(msg, "UTF8")
+            msg = bytes(msg, "utf-8")
+
+        headers.append(('Content-Length', str(len(msg))))
 
         super(HTTPException, self).__init__(code, msg, headers)
         self.code = code
@@ -138,8 +139,7 @@ class Application:
             # Validate the method
             method = env["REQUEST_METHOD"].upper()
             if method != "POST":
-                raise HTTPException(405, "Method not allowed (%s)." % method,
-                                    ("Allow", "POST"))
+                raise HTTPException(405, "Method not allowed (%s)." % method)
 
             # Parse the request
             try:

--- a/kdcproxy/codec.py
+++ b/kdcproxy/codec.py
@@ -129,6 +129,7 @@ class KPASSWDProxyRequest(ProxyRequest):
     def __str__(self):
         tmp = super(KPASSWDProxyRequest, self).__str__()
         tmp += " (version 0x%04x)" % self.version
+        return tmp
 
 
 def decode(data):

--- a/kdcproxy/config/__init__.py
+++ b/kdcproxy/config/__init__.py
@@ -49,15 +49,18 @@ class IConfig(IResolver):
 
 class KDCProxyConfig(IConfig):
     GLOBAL = "global"
+    default_filename = "/etc/kdcproxy.conf"
 
     def __init__(self, filename=None):
         self.__cp = configparser.ConfigParser()
         if filename is None:
             filename = os.environ.get("KDCPROXY_CONFIG", None)
+        if filename is None:
+            filename = self.default_filename
         try:
-            self.__cp.read(filename or "/etc/kdcproxy.conf")
+            self.__cp.read(filename)
         except configparser.Error:
-            logging.log(logging.ERROR, "Unable to read config file: %s" % file)
+            logging.error("Unable to read config file: %s", filename)
 
         try:
             mod = self.__cp.get(self.GLOBAL, "configs")

--- a/kdcproxy/config/mit.py
+++ b/kdcproxy/config/mit.py
@@ -24,101 +24,179 @@ import sys
 
 try:
     import urllib.parse as urlparse
-except ImportError:
+except ImportError:  # pragma: no cover
     import urlparse
 
 from kdcproxy.config import IConfig
 
 
+class KRB5Error(Exception):
+    pass
+
+PY3 = sys.version_info[0] == 3
+
+try:
+    LIBKRB5 = ctypes.CDLL('libkrb5.so.3')
+except OSError as e:  # pragma: no cover
+    LIBKRB5 = e
+else:
+    class c_text_p(ctypes.c_char_p):  # noqa
+        """A c_char_p variant that can handle UTF-8 text"""
+        @classmethod
+        def from_param(cls, value):
+            if value is None:
+                return None
+            if PY3 and isinstance(value, str):
+                return value.encode('utf-8')
+            elif not PY3 and isinstance(value, unicode):  # noqa
+                return value.encode('utf-8')
+            elif not isinstance(value, bytes):
+                raise TypeError(value)
+            else:
+                return value
+
+        @property
+        def text(self):
+            value = self.value
+            if value is None:
+                return None
+            elif not isinstance(value, str):
+                return value.decode('utf-8')
+            return value
+
+    class _krb5_context(ctypes.Structure):  # noqa
+        """krb5/krb5.h struct _krb5_context"""
+        __slots__ = ()
+        _fields_ = []
+
+    class _profile_t(ctypes.Structure):  # noqa
+        """profile.h struct _profile_t"""
+        __slots__ = ()
+        _fields_ = []
+
+    def krb5_errcheck(result, func, arguments):
+        """Error checker for krb5_error return value"""
+        if result != 0:
+            raise KRB5Error(result, func.__name__, arguments)
+
+    krb5_context = ctypes.POINTER(_krb5_context)
+    profile_t = ctypes.POINTER(_profile_t)
+    iter_p = ctypes.c_void_p
+    krb5_error = ctypes.c_int32
+
+    krb5_init_context = LIBKRB5.krb5_init_context
+    krb5_init_context.argtypes = (ctypes.POINTER(krb5_context), )
+    krb5_init_context.restype = krb5_error
+    krb5_init_context.errcheck = krb5_errcheck
+
+    krb5_free_context = LIBKRB5.krb5_free_context
+    krb5_free_context.argtypes = (krb5_context, )
+    krb5_free_context.retval = None
+
+    krb5_get_profile = LIBKRB5.krb5_get_profile
+    krb5_get_profile.argtypes = (krb5_context, ctypes.POINTER(profile_t))
+    krb5_get_profile.restype = krb5_error
+    krb5_get_profile.errcheck = krb5_errcheck
+
+    profile_release = LIBKRB5.profile_release
+    profile_release.argtypes = (profile_t, )
+    profile_release.restype = None
+
+    profile_iterator_create = LIBKRB5.profile_iterator_create
+    profile_iterator_create.argtypes = (profile_t,
+                                        ctypes.POINTER(c_text_p),
+                                        ctypes.c_int,
+                                        ctypes.POINTER(iter_p))
+    profile_iterator_create.restype = krb5_error
+    profile_iterator_create.errcheck = krb5_errcheck
+
+    profile_iterator_free = LIBKRB5.profile_iterator_free
+    profile_iterator_free.argtypes = (ctypes.POINTER(iter_p), )
+    profile_iterator_free.retval = None
+
+    profile_iterator = LIBKRB5.profile_iterator
+    profile_iterator.argtypes = (ctypes.POINTER(iter_p),
+                                 ctypes.POINTER(c_text_p),
+                                 ctypes.POINTER(c_text_p))
+    profile_iterator.restype = krb5_error
+    profile_iterator.errcheck = krb5_errcheck
+
+    profile_get_boolean = LIBKRB5.profile_get_boolean
+    profile_get_boolean.argtypes = (profile_t,
+                                    c_text_p,
+                                    c_text_p,
+                                    c_text_p,
+                                    ctypes.c_int,
+                                    ctypes.POINTER(ctypes.c_int))
+    profile_get_boolean.restype = krb5_error
+    profile_get_boolean.errcheck = krb5_errcheck
+
+
 class KRB5Profile:
 
-    class Error(Exception):
-        pass
-
-    class Library:
-
-        def __init__(self):
-            self.__dll = ctypes.CDLL('libkrb5.so.3')
-
-        def __getattr__(self, name):
-            return getattr(self.__dll, name)
-
-        def exc(self, name):
-            def inner(*args):
-                func = getattr(self.__dll, name)
-                retval = func(*args)
-                if retval != 0:
-                    raise KRB5Profile.Error(retval)
-            return inner
-
     class Iterator:
-
-        def __init__(self, lib, profile, *args):
-            self.__lib = lib
-
+        def __init__(self, profile, *args):
             # Convert string arguments to UTF8 bytes
-            args = list(args) + [None, ]
-            for i in range(len(args)):
-                if type(args[i]) not in (bytes, type(None)):
-                    args[i] = bytes(args[i], "UTF8")
-
+            args = [c_text_p.from_param(arg) for arg in args]
+            args.append(None)
             # Create array
-            array = ctypes.c_char_p * len(args)
+            array = c_text_p * len(args)
             self.__path = array(*args)
-
             # Call the function
-            self.__iterator = ctypes.c_void_p()
-            func = self.__lib.exc("profile_iterator_create")
-            func(profile, self.__path, 1, ctypes.byref(self.__iterator))
+            self.__iterator = iter_p()
+            profile_iterator_create(profile,
+                                    self.__path,
+                                    1,
+                                    ctypes.byref(self.__iterator))
 
         def __iter__(self):
             return self
 
         def __next__(self):
             try:
-                name = ctypes.c_char_p()
-                value = ctypes.c_char_p()
-                func = self.__lib.exc("profile_iterator")
-                func(ctypes.byref(self.__iterator), ctypes.byref(name),
-                     ctypes.byref(value))
+                name = c_text_p()
+                value = c_text_p()
+                profile_iterator(ctypes.byref(self.__iterator),
+                                 ctypes.byref(name),
+                                 ctypes.byref(value))
                 if not name.value:
-                    raise KRB5Profile.Error()
-
-                key = name.value
-                if not isinstance(key, str):
-                    key = str(key, "UTF8")
-
-                val = value.value
-                if type(val) not in (str, type(None)):
-                    val = str(val, "UTF8")
-
-                return (key, val)
-            except KRB5Profile.Error:
-                self.__lib.profile_iterator_free(ctypes.byref(self.__iterator))
+                    raise KRB5Error
+                return name.text, value.text
+            except KRB5Error:
+                profile_iterator_free(ctypes.byref(self.__iterator))
+                self.__iterator = None
                 raise StopIteration()
 
+        def __del__(self):
+            if self.__iterator:  # pragma: no cover
+                profile_iterator_free(ctypes.byref(self.__iterator))
+                self.__iterator = None
+
         # Handle iterator API change
-        if sys.version_info.major == 2:
+        if not PY3:
             next = __next__
 
     def __init__(self):
-        self.__lib = KRB5Profile.Library()
-
-        self.__context = ctypes.c_void_p()
-        func = self.__lib.exc("krb5_init_context")
-        func(ctypes.byref(self.__context))
-
-        self.__profile = ctypes.c_void_p()
-        func = self.__lib.exc("krb5_get_profile")
-        func(self.__context, ctypes.byref(self.__profile))
+        self.__context = self.__profile = None
+        if isinstance(LIBKRB5, Exception):  # pragma: no cover
+            raise LIBKRB5
+        context = krb5_context()
+        krb5_init_context(ctypes.byref(context))
+        self.__context = context
+        profile = profile_t()
+        krb5_get_profile(context, ctypes.byref(profile))
+        self.__profile = profile
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, value, traceback):
         if self.__context:
-            self.__lib.krb5_free_context(self.__context)
+            krb5_free_context(self.__context)
             self.__context = None
+        if self.__profile:
+            profile_release(self.__profile)
+            self.__profile = None
 
     def __del__(self):
         self.__exit__(None, None, None)
@@ -127,22 +205,16 @@ class KRB5Profile:
         return self.section(name)
 
     def get_bool(self, name, subname=None, subsubname=None, default=False):
-        val = ctypes.c_uint(1)
-        if sys.version_info[0] == 3:
-            name = name.encode('ascii')
-            if subname is not None:
-                subname = subname.encode('ascii')
-            if subsubname is not None:
-                subsubname = subsubname.encode('ascii')
-        self.__lib.exc("profile_get_boolean")(self.__profile,
-                                              name, subname, subsubname,
-                                              int(default), ctypes.byref(val))
+        val = ctypes.c_int(1)
+        profile_get_boolean(self.__profile,
+                            name, subname, subsubname,
+                            int(default), ctypes.byref(val))
         return bool(val.value)
 
     def section(self, *args):
         output = []
 
-        for k, v in KRB5Profile.Iterator(self.__lib, self.__profile, *args):
+        for k, v in KRB5Profile.Iterator(self.__profile, *args):
             if v is None:
                 tmp = args + (k,)
                 output.append((k, self.section(*tmp)))

--- a/kdcproxy/config/mit.py
+++ b/kdcproxy/config/mit.py
@@ -128,6 +128,12 @@ class KRB5Profile:
 
     def get_bool(self, name, subname=None, subsubname=None, default=False):
         val = ctypes.c_uint(1)
+        if sys.version_info[0] == 3:
+            name = name.encode('ascii')
+            if subname is not None:
+                subname = subname.encode('ascii')
+            if subsubname is not None:
+                subsubname = subsubname.encode('ascii')
         self.__lib.exc("profile_get_boolean")(self.__profile,
                                               name, subname, subsubname,
                                               int(default), ctypes.byref(val))
@@ -156,7 +162,7 @@ class MITConfig(IConfig):
             self.__config["dns"] = prof.get_bool("libdefaults",
                                                  "dns_fallback",
                                                  default=True)
-            if "dns_lookup_kdc" in prof.section("libdefaults"):
+            if "dns_lookup_kdc" in dict(prof.section("libdefaults")):
                 self.__config["dns"] = prof.get_bool("libdefaults",
                                                      "dns_lookup_kdc",
                                                      default=True)
@@ -184,8 +190,8 @@ class MITConfig(IConfig):
         rconf = self.__config.get("realms", {}).get(realm, {})
 
         if kpasswd:
-            servers = rconf.get('kpasswd_server', [])
-            servers += rconf.get('admin_server', [])
+            servers = list(rconf.get('kpasswd_server', []))
+            servers.extend(rconf.get('admin_server', []))
         else:
             servers = rconf.get('kdc', [])
 

--- a/tests.krb5.conf
+++ b/tests.krb5.conf
@@ -1,0 +1,17 @@
+[libdefaults]
+  default_realm = KDCPROXY.TEST
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+
+[realms]
+  KDCPROXY.TEST = {
+    kdc = k1.kdcproxy.test.:88
+    kdc = k2.kdcproxy.test.:1088
+    admin_server = adm.kdcproxy.test.:749
+    kpasswd_server = adm.kdcproxy.test.:1749
+    default_domain = kdcproxy.test
+  }
+
+[domain_realm]
+  .kdcproxy.test = KDCPROXY.TEST
+  kdcproxy.test = KDCPROXY.TEST

--- a/tests.py
+++ b/tests.py
@@ -20,12 +20,15 @@
 # THE SOFTWARE.
 
 import unittest
+from base64 import b64decode
+
+from pyasn1.codec.der import decoder
 
 from webtest import TestApp
 
 import kdcproxy
 # from kdcproxy import asn1
-# from kdcproxy import codec
+from kdcproxy import codec
 # from kdcproxy import config
 # from kdcproxy.config import mit
 
@@ -39,6 +42,91 @@ class KDCProxyWSGITests(unittest.TestCase):
         self.assertEqual(r.status_code, 405)
         self.assertEqual(r.status, '405 Method Not Allowed')
         self.assertEqual(r.text, 'Method not allowed (GET).')
+
+
+def decode(data):
+    data = data.replace(b'\\n', b'')
+    data = data.replace(b' ', b'')
+    return b64decode(data)
+
+
+class KDCProxyCodecTests(unittest.TestCase):
+    realm = 'FREEIPA.LOCAL'
+
+    asreq1 = decode(b"""
+        MIHEoIGwBIGtAAAAqWqBpjCBo6EDAgEFogMCAQqjDjAMMAqhBAICAJWiAgQApIGGMIGDo
+        AcDBQBAAAAQoRIwEKADAgEBoQkwBxsFYWRtaW6iDxsNRlJFRUlQQS5MT0NBTKMiMCCgAw
+        IBAqEZMBcbBmtyYnRndBsNRlJFRUlQQS5MT0NBTKURGA8yMDE1MDUxNDEwNDIzOFqnBgI
+        EEchjtagUMBICARICARECARACARcCARkCARqhDxsNRlJFRUlQQS5MT0NBTA==
+    """)
+
+    asreq2 = decode(b"""
+        MIIBJaCCARAEggEMAAABCGqCAQQwggEAoQMCAQWiAwIBCqNrMGkwDaEEAgIAhaIFBANNS
+        VQwTKEDAgECokUEQzBBoAMCARKiOgQ48A25MkXWM1ZrTvaYMJcbFX7Hp7JW11omIwqOQd
+        SSGKVZ9mzYLuL19RRhX9xrXbQS0klXRVgRWHMwCqEEAgIAlaICBACkgYYwgYOgBwMFAEA
+        AABChEjAQoAMCAQGhCTAHGwVhZG1pbqIPGw1GUkVFSVBBLkxPQ0FMoyIwIKADAgECoRkw
+        FxsGa3JidGd0Gw1GUkVFSVBBLkxPQ0FMpREYDzIwMTUwNTE0MTA0MjM4WqcGAgRXSy38q
+        BQwEgIBEgIBEQIBEAIBFwIBGQIBGqEPGw1GUkVFSVBBLkxPQ0FM
+    """)
+
+    tgsreq = decode(b"""
+        MIIDxaCCA7AEggOsAAADqGyCA6QwggOgoQMCAQWiAwIBDKOCAxowggMWMIICL6EDAgEBo
+        oICJgSCAiJuggIeMIICGqADAgEFoQMCAQ6iBwMFAAAAAACjggFGYYIBQjCCAT6gAwIBBa
+        EPGw1GUkVFSVBBLkxPQ0FMoiIwIKADAgECoRkwFxsGa3JidGd0Gw1GUkVFSVBBLkxPQ0F
+        Mo4IBADCB/aADAgESoQMCAQGigfAEge3ODJahLoTF0Xl+DeWdBqy79TSJv6+L23WEuBQi
+        CnvmiLGxFhe/zuW6LN9O0Ekb3moX4qFKW7bF/gw0GuuMemkIjLaZ2M5mZiaQQ456fU5dA
+        +ntLs8C407x3TVu68TM1aDvQgyKVpQgTdjxTZVmdinueIxOQ5z2nTIyjA9W94umGrPIcc
+        sOfwvTEqyVpXrQcXr2tj/o/WcDLh/hHMhlHRBr9uLBLdVh2xR1yRbwe/n1UsXckxRi/A/
+        +YgGSW7YDFBXij9RpGaE0bpa8e4u/EkcQEgu66nwVrfNs/TvsTJ1VnL5LpicDZvXzm0gO
+        y3OkgbowgbegAwIBEqKBrwSBrIWE4ylyvY7JpiGCJQJKpv8sd3tFK054UTDvs1UuBAiWz
+        IwNOddrdb4YKKGC/ce3e/sX+CBvISNPsOqX4skXK0gnMCJaCU6H1QKNeJu1TJm8GxPQ28
+        1B8ZrCnv9Vzput0YIXAFK1eoAfe9qnJVktLL9uwYfV7D4GDU634KtEvPeDTBVMmTVXpUR
+        5HIXiE4Qw6bON74Ssg4n8YDoO0ZXdOIOOUh1+soMoUzjg2XIwgeChBAICAIiigdcEgdSg
+        gdEwgc6hFzAVoAMCARChDgQMmmZqel1e6bYuSZBxooGyMIGvoAMCARKigacEgaQwxX40v
+        E6S6aNej2Siwkr/JA/70sbSoR8JrET9q6DW0rtawnOzKGYYSNEs8GLWgeSQaqIKuWXDuT
+        R898vv3RYY4nn1wSNQFFSOHxaVqdRzY55Z7HbO7OPTyQhPI31f1m8Tuxl7kpMM74Yhypj
+        iQCe8RHrJUyCQay8AonQY11pRvRlwzcnbrB5GhegVmtp1Qhtv0Lj//yLHZ4MdVh5FV2N2
+        8odz7KR2MHSgBwMFAEABAACiDxsNRlJFRUlQQS5MT0NBTKMnMCWgAwIBAaEeMBwbBGh0d
+        HAbFGlwYXNydi5mcmVlaXBhLmxvY2FspREYDzIwMTUwNTE0MTA0MjM4WqcGAgRVUzCzqB
+        QwEgIBEgIBEQIBEAIBFwIBGQIBGqEPGw1GUkVFSVBBLkxPQ0FM
+    """)
+
+    kpasswdreq = decode(b"""
+        MIICeKCCAmMEggJfAAACWwJbAAECAm6CAf4wggH6oAMCAQWhAwIBDqIHAwUAAAAAAKOCA
+        UFhggE9MIIBOaADAgEFoQ8bDUZSRUVJUEEuTE9DQUyiHTAboAMCAQGhFDASGwZrYWRtaW
+        4bCGNoYW5nZXB3o4IBADCB/aADAgESoQMCAQGigfAEge3swqU5Z7QS15Hf8+o9UPdl3H7
+        Xx+ZpEsg2Fj9b0KB/xnnkbTbJs4oic8h30jOtVfq589lWN/jx3CIRdyPndTfJLZCQZN4Q
+        sm6Gye/czzfMFtIOdYSdDL0EpW5/adRsbX253dxqy7431s9Jxsx4xXIowOkD/cCHcrAw3
+        SLchLXVXGbgcnnphAo+po8cJ7omMF0c0F0eOplKQkbbjoNJSO/TeIQJdgmUrxpy9c8Uhc
+        ScdkajtyxGD9YvXDc8Ik7OCFn03e9bd791qasiBSTgCjWjV3IvcDohjF/RpxftA5LxmGS
+        /C1KSG1AZBqivSMOkgZ8wgZygAwIBEqKBlASBkerR33SV6Gv+yTLbqByadkgmCAu4w1ms
+        NifEss5TAhcEJEnpyqPbZgMfvksc+ULsnsdzovskhd1NbhJx+f9B0mxUzpNw1uRXMVbNw
+        FGUSlYwVr+h1Hzs7/PLSsRV/jPNA+kbqbTcIkPOWe8OGGWuvbp24w6yrY3rcUCbEfhs+m
+        xuSIJwMDwEUb2GqRwTkBhCGgd1UTBPoAMCAQWhAwIBFaNDMEGgAwIBEqI6BDh433pZMyL
+        WiOUtyZnqOyiMoCe7ulv7TVyE5PGccaA3vXPzzBwh5P9wEFDl0alUBuHOKgBbtzOAgKEP
+        Gw1GUkVFSVBBLkxPQ0FM
+    """)
+
+    def assert_decode(self, data, cls):
+        outer = codec.decode(data)
+        self.assertEqual(outer.realm, self.realm)
+        self.assertIsInstance(outer, cls)
+        if cls is not codec.KPASSWDProxyRequest:
+            inner, err = decoder.decode(outer.request[outer.OFFSET:],
+                                        asn1Spec=outer.TYPE())
+            if err:
+                self.fail(err)
+            self.assertIsInstance(inner, outer.TYPE)
+
+    def test_asreq(self):
+        self.assert_decode(self.asreq1, codec.ASProxyRequest)
+        self.assert_decode(self.asreq2, codec.ASProxyRequest)
+
+    def test_tgsreq(self):
+        self.assert_decode(self.tgsreq, codec.TGSProxyRequest)
+
+    def test_kpasswdreq(self):
+        self.assert_decode(self.kpasswdreq, codec.KPASSWDProxyRequest)
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2015, Red Hat, Inc.
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest
+
+from webtest import TestApp
+
+import kdcproxy
+# from kdcproxy import asn1
+# from kdcproxy import codec
+# from kdcproxy import config
+# from kdcproxy.config import mit
+
+
+class KDCProxyWSGITests(unittest.TestCase):
+    def setUp(self):  # noqa
+        self.app = TestApp(kdcproxy.application)
+
+    def test_get(self):
+        r = self.app.get('/', expect_errors=True)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(r.status, '405 Method Not Allowed')
+        self.assertEqual(r.text, 'Method not allowed (GET).')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+envlist = py27,py34,pep8,py3pep8,doc
+
+[testenv]
+deps =
+    pytest
+    WebTest
+    pyasn1
+    py27: dnspython
+    py34: dnspython3
+commands = py.test {posargs} tests.py
+
+[testenv:pep8]
+basepython = python2.7
+deps =
+    flake8
+    flake8-import-order
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:py3pep8]
+basepython = python3.4
+deps =
+    flake8
+    flake8-import-order
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:doc]
+deps =
+    doc8
+    docutils
+basepython = python2.7
+commands =
+    doc8 --allow-long-titles README 
+    python setup.py check --restructuredtext --metadata --strict
+
+[flake8]
+exclude = .tox,*.egg,dist,build
+show-source = true
+max-line-length = 79
+application-import-names = kdcproxy
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,15 @@ envlist = py27,py34,pep8,py3pep8,doc
 [testenv]
 deps =
     pytest
+    coverage
     WebTest
     pyasn1
     py27: dnspython
     py34: dnspython3
-commands = py.test {posargs} tests.py
+    py27: mock
+commands =
+    coverage run -m pytest --capture=no --strict {posargs}
+    coverage report -m
 
 [testenv:pep8]
 basepython = python2.7
@@ -36,6 +40,9 @@ basepython = python2.7
 commands =
     doc8 --allow-long-titles README 
     python setup.py check --restructuredtext --metadata --strict
+
+[pytest]
+python_files = tests*.py
 
 [flake8]
 exclude = .tox,*.egg,dist,build

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     docutils
 basepython = python2.7
 commands =
-    doc8 --allow-long-titles README 
+    doc8 --allow-long-titles README
     python setup.py check --restructuredtext --metadata --strict
 
 [pytest]
@@ -49,4 +49,3 @@ exclude = .tox,*.egg,dist,build
 show-source = true
 max-line-length = 79
 application-import-names = kdcproxy
-


### PR DESCRIPTION
Changes:

* test infrastructure with tox, py.test, coverage and flake8
* pep8-tify source code
* update README
* use ctypes function prototypes, error check callback and text datatype to make code easier to read and type safe.

Bug fixes:

* kdcproxy.config.mit: get_bool() wasn't working on Python because char* input parameters were unicode instead of bytes
* kdcproxy.config.mit: dns_lookup_kdc option was ignored. prof.section() returns a list of tuples.
* kdcproxy.config.mit: each kpasswd lookup modified the internal kpasswd_server list.
* fix internal server error on GET requests
* fix logging error
* add missing return in KPASSWDProxyRequest.__str__
* accumulate reply in a buffer until EOF is signalled. recv() may not return the full response.
