### PR TITLE
Internal Server Error with GET request

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -41,13 +41,14 @@ class HTTPException(Exception):
 
     def __init__(self, code, msg, headers=[]):
         headers = list(filter(lambda h: h[0] != 'Content-Length', headers))
-        headers.append(('Content-Length', str(len(msg))))
 
         if 'Content-Type' not in dict(headers):
-            headers.append(('Content-Type', 'text/plain'))
+            headers.append(('Content-Type', 'text/plain; charset=utf-8'))
 
         if sys.version_info.major == 3 and isinstance(msg, str):
-            msg = bytes(msg, "UTF8")
+            msg = bytes(msg, "utf-8")
+
+        headers.append(('Content-Length', str(len(msg))))
 
         super(HTTPException, self).__init__(code, msg, headers)
         self.code = code
@@ -138,8 +139,7 @@ class Application:
             # Validate the method
             method = env["REQUEST_METHOD"].upper()
             if method != "POST":
-                raise HTTPException(405, "Method not allowed (%s)." % method,
-                                    ("Allow", "POST"))
+                raise HTTPException(405, "Method not allowed (%s)." % method)
 
             # Parse the request
             try:


### PR DESCRIPTION
There is a bug in the HTTP method check around line 140. I found the problem while I was playing around with KDC proxy.

```
[Tue May 12 09:29:48.189677 2015] [wsgi:error] [pid 1730] ipa: INFO: *** PROCESS START ***
[Tue May 12 09:29:54.564490 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48] mod_wsgi (pid=1733): Exception occurred processing WSGI script '/usr/lib/python2.7/site-packages/kdcproxy/__init__.py'.
[Tue May 12 09:29:54.564561 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48] Traceback (most recent call last):
[Tue May 12 09:29:54.564628 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48]   File "/usr/lib/python2.7/site-packages/kdcproxy/__init__.py", line 141, in __call__
[Tue May 12 09:29:54.564789 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48]     ("Allow", "POST"))
[Tue May 12 09:29:54.564867 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48]   File "/usr/lib/python2.7/site-packages/kdcproxy/__init__.py", line 46, in __init__
[Tue May 12 09:29:54.564939 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48]     if 'Content-Type' not in dict(headers):
[Tue May 12 09:29:54.565004 2015] [wsgi:error] [pid 1733] [remote 192.168.122.1:48] ValueError: dictionary update sequence element #0 has length 5; 2 is required
```

# cat /etc/httpd/conf.d/kdc.conf 
# Configure mod_wsgi handler for /kdc
WSGIDaemonProcess kdc processes=1 threads=1 maximum-requests=10
WSGIProcessGroup kdc
WSGIApplicationGroup kdc
WSGIImportScript /usr/lib/python2.7/site-packages/kdcproxy/__init__.py process-group=kdc application-group=kdc
WSGIScriptAlias /kdc /usr/lib/python2.7/site-packages/kdcproxy/__init__.py
WSGIScriptReloading On

<Location "/kdc">
  Satisfy Any
  Order Deny,Allow
  Allow from all
</Location>

# rpm -q python-kdcproxy 
python-kdcproxy-0.2.1-1.fc21.noarch