### PR TITLE
Fix tox compatibility issue on Fedora 21

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,20 @@ deps =
     coverage
     WebTest
     pyasn1
-    py27: dnspython
-    py34: dnspython3
-    py27: mock
 commands =
     coverage run -m pytest --capture=no --strict {posargs}
     coverage report -m
+
+[testenv:py27]
+deps =
+    {[testenv]deps}
+    dnspython
+    mock
+
+[testenv:py34]
+deps =
+    {[testenv]deps}
+    dnspython3
 
 [testenv:pep8]
 basepython = python2.7


### PR DESCRIPTION
Fedora 21 has python-tox-1.7.1. The version doesn't support conditional
requirements.

The patch fixes the broken build on F21.